### PR TITLE
Fix non-FastBoot apps and add test scenarios to test it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "7"
 
 sudo: false
 
@@ -13,18 +13,15 @@ cache:
   yarn: true
 
 env:
-  # We recommend testing LTS’s and latest stable release (bonus points to beta/canary)
-  - EMBER_TRY_SCENARIO=ember-lts-2.4
-  - EMBER_TRY_SCENARIO=ember-lts-2.8
-  - EMBER_TRY_SCENARIO=ember-release
-  - EMBER_TRY_SCENARIO=ember-beta
-  - EMBER_TRY_SCENARIO=ember-canary
-  - EMBER_TRY_SCENARIO=ember-default
+  - EMBER_TRY_SCENARIO=ember-lts-without-fastboot
+  - EMBER_TRY_SCENARIO=ember-latest-without-fastboot
+  - EMBER_TRY_SCENARIO=ember-beta-without-fastboot
+  - EMBER_TRY_SCENARIO=ember-lts-with-fastboot
+  - EMBER_TRY_SCENARIO=ember-latest-with-fastboot
+  - EMBER_TRY_SCENARIO=ember-beta-with-fastboot
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
@@ -37,4 +34,4 @@ script:
   - yarn run lint
   # Usually, it’s ok to finish the test scenario without reverting
   # to the addon's original dependency state, skipping "cleanup".
-  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO test --skip-cleanup
+  - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO --skip-cleanup

--- a/addon/services/best-language.js
+++ b/addon/services/best-language.js
@@ -1,12 +1,14 @@
 import Ember from 'ember';
 
-const {inject} = Ember;
+const {computed, getOwner} = Ember;
 
 export default Ember.Service.extend({
-  fastboot: inject.service('fastboot'),
+  fastboot: computed(function() {
+    return getOwner(this).lookup('service:fastboot');
+  }),
 
   bestLanguage(languages) {
-    const userLanguages = this.get('fastboot.isFastBoot')
+    const userLanguages = this.getWithDefault('fastboot.isFastBoot', false)
       ? this._fetchHeaderLanguages()
       : this._fetchBrowserLanguages();
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,94 +1,65 @@
 /* eslint-env node */
 
-'use strict';
+module.exports = function() {
+  return {
+    command: 'ember test',
+    useYarn: true,
+    scenarios: [
+      {
+        name: 'ember-lts-without-fastboot',
+        command: 'ember test --filter "when running inside FastBoot" --invert',
+        npm: {
+          devDependencies: {
+            'ember-source': 'lts',
+            'ember-cli-fastboot': null
+          }
+        }
+      },
+      {
+        name: 'ember-latest-without-fastboot',
+        command: 'ember test --filter "when running inside FastBoot" --invert',
+        npm: {
+          devDependencies: {
+            'ember-source': 'latest',
+            'ember-cli-fastboot': null
+          }
+        }
+      },
+      {
+        name: 'ember-beta-without-fastboot',
+        command: 'ember test --filter "when running inside FastBoot" --invert',
+        npm: {
+          devDependencies: {
+            'ember-source': 'beta',
+            'ember-cli-fastboot': null
+          }
+        }
+      },
+      {
+        name: 'ember-lts-with-fastboot',
+        npm: {
+          devDependencies: {
+            'ember-source': 'lts'
+          }
+        }
+      },
+      {
+        name: 'ember-latest-with-fastboot',
 
-module.exports = {
-  scenarios: [
-    {
-      name: 'ember-lts-2.4',
-      bower: {
-        dependencies: {
-          ember: 'components/ember#lts-2-4'
-        },
-        resolutions: {
-          ember: 'lts-2-4'
+        npm: {
+          devDependencies: {
+            'ember-source': 'latest'
+          }
         }
       },
-      npm: {
-        devDependencies: {
-          'ember-source': null
+      {
+        name: 'ember-beta-with-fastboot',
+        npm: {
+          devDependencies: {
+            'ember-source': 'beta'
+          }
         }
       }
-    },
-    {
-      name: 'ember-lts-2.8',
-      bower: {
-        dependencies: {
-          ember: 'components/ember#lts-2-8'
-        },
-        resolutions: {
-          ember: 'lts-2-8'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-release',
-      bower: {
-        dependencies: {
-          ember: 'components/ember#release'
-        },
-        resolutions: {
-          ember: 'release'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-beta',
-      bower: {
-        dependencies: {
-          ember: 'components/ember#beta'
-        },
-        resolutions: {
-          ember: 'beta'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-canary',
-      bower: {
-        dependencies: {
-          ember: 'components/ember#canary'
-        },
-        resolutions: {
-          ember: 'canary'
-        }
-      },
-      npm: {
-        devDependencies: {
-          'ember-source': null
-        }
-      }
-    },
-    {
-      name: 'ember-default',
-      npm: {
-        devDependencies: {}
-      }
-    }
-  ]
+    ]
+  };
 };

--- a/tests/unit/services/best-language-test.js
+++ b/tests/unit/services/best-language-test.js
@@ -4,9 +4,7 @@ import {describe, before, beforeEach, it} from 'mocha';
 import {setupTest} from 'ember-mocha';
 
 describe('Unit | Service | best-language', () => {
-  setupTest('service:best-language', {
-    needs: ['service:fastboot']
-  });
+  setupTest('service:best-language');
 
   describe('when running inside FastBoot', () => {
     describe('and accept-language header is sent', () => {
@@ -135,15 +133,6 @@ describe('Unit | Service | best-language', () => {
   });
 
   describe('when running inside the browser', () => {
-    const fastbootStub = Ember.Service.extend({
-      isFastboot: false
-    });
-
-    beforeEach(function() {
-      this.register('service:fastboot', fastbootStub);
-      this.inject.service('fastboot');
-    });
-
     describe('with different language and languages properties', () => {
       before(() => {
         Object.defineProperty(window.navigator, 'languages', {value: ['fr', 'en-US', 'en'], configurable: true});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2294,6 +2294,24 @@ ember-try@^0.2.14:
     semver "^5.1.0"
     sync-exec "^0.6.2"
 
+ember-try@^0.2.17:
+  version "0.2.17"
+  resolved "https://registry.yarnpkg.com/ember-try/-/ember-try-0.2.17.tgz#0ffff687630291b4cf94f5b196e728c1a92d8aec"
+  dependencies:
+    chalk "^1.0.0"
+    cli-table2 "^0.2.0"
+    core-object "^1.1.0"
+    debug "^2.2.0"
+    ember-cli-version-checker "^1.1.6"
+    ember-try-config "^2.0.1"
+    extend "^3.0.0"
+    fs-extra "^0.26.0"
+    promise-map-series "^0.2.1"
+    resolve "^1.1.6"
+    rimraf "^2.3.2"
+    rsvp "^3.0.17"
+    semver "^5.1.0"
+
 encodeurl@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.1.tgz#79e3d58655346909fe6f0f45a5de68103b294d20"


### PR DESCRIPTION
This adds support for non-FastBoot apps and tests against the important releases of Ember with and without FastBoot.

Thanks @basz for the code, I copied it here (with small fixes to make eslint pass :wink:) to make sure that my changes would make the build pass on Travis