### PR TITLE
Support having the country codes within the supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,14 @@ export default Ember.Route.extend({
   bestLanguage: inject.service('best-language'),
 
   beforeModel() {
-    const bestLanguage = this.get('bestLanguage').bestLanguage(['fr', 'de']);
+    const bestLanguage = this.get('bestLanguage').bestLanguage(['fr', 'de', 'en-US']);
     // => null
 
-    const bestLanguageOrFirst = this.get('bestLanguage').bestLanguageOrFirst(['fr', 'de']);
+    const bestLanguageOrFirst = this.get('bestLanguage').bestLanguageOrFirst(['fr', 'de', 'en-US']);
     // => {language: 'fr', baseLanguage: 'fr', score: 0}
   }
 });
 ```
-
-__Note: for the time being, we only support an array of language codes without country code e.g. 'es'. PRs welcome! :)__
 
 ## Contributing
 

--- a/tests/unit/services/best-language-test.js
+++ b/tests/unit/services/best-language-test.js
@@ -50,6 +50,18 @@ describe('Unit | Service | best-language', () => {
           });
         });
 
+        it('should handle supported languages with country code', function() {
+          const service = this.subject();
+
+          const supportedLanguages = ['en-CA', 'en-US', 'fr'];
+
+          expect(service.bestLanguage(supportedLanguages)).to.deep.equal({
+            language: 'en-US',
+            baseLanguage: 'en',
+            score: 1
+          });
+        });
+
         it('should return `null` when none match', function() {
           const service = this.owner.lookup('service:best-language');
 
@@ -70,13 +82,23 @@ describe('Unit | Service | best-language', () => {
           );
         });
 
+        it('should handle supported languages with country code', function() {
+          const service = this.subject();
+
+          const supportedLanguages = ['en-CA', 'en-US', 'fr'];
+
+          expect(service.bestLanguageOrFirst(supportedLanguages)).to.deep.equal(
+            {language: 'en-US', baseLanguage: 'en', score: 1}
+          );
+        });
+
         it('should return the first supported language when none match', function() {
           const service = this.owner.lookup('service:best-language');
 
-          const supportedLanguages = ['de', 'es'];
+          const supportedLanguages = ['de-DE', 'es'];
 
           expect(service.bestLanguageOrFirst(supportedLanguages)).to.deep.equal(
-            {language: 'de', baseLanguage: 'de', score: 0}
+            {language: 'de-DE', baseLanguage: 'de', score: 0}
           );
         });
       });
@@ -250,6 +272,18 @@ describe('Unit | Service | best-language', () => {
           });
         });
 
+        it('should handle supported languages with country code', function() {
+          const service = this.subject();
+
+          const supportedLanguages = ['en-CA', 'en-US', 'fr'];
+
+          expect(service.bestLanguage(supportedLanguages)).to.deep.equal({
+            language: 'en-US',
+            baseLanguage: 'en',
+            score: 1
+          });
+        });
+
         it('should return `null` when none match', function() {
           const service = this.owner.lookup('service:best-language');
 
@@ -270,13 +304,23 @@ describe('Unit | Service | best-language', () => {
           );
         });
 
+        it('should handle supported languages with country code', function() {
+          const service = this.subject();
+
+          const supportedLanguages = ['en-CA', 'en-US', 'fr'];
+
+          expect(service.bestLanguageOrFirst(supportedLanguages)).to.deep.equal(
+            {language: 'en-US', baseLanguage: 'en', score: 1}
+          );
+        });
+
         it('should return the first supported language when none match', function() {
           const service = this.owner.lookup('service:best-language');
 
-          const supportedLanguages = ['de', 'es'];
+          const supportedLanguages = ['de-DE', 'es'];
 
           expect(service.bestLanguageOrFirst(supportedLanguages)).to.deep.equal(
-            {language: 'de', baseLanguage: 'de', score: 0}
+            {language: 'de-DE', baseLanguage: 'de', score: 0}
           );
         });
       });

--- a/tests/unit/services/best-language-test.js
+++ b/tests/unit/services/best-language-test.js
@@ -26,9 +26,9 @@ describe('Unit | Service | best-language', () => {
           const service = this.owner.lookup('service:best-language');
 
           const expectedLanguages = [
-            {language: 'en-US', score: 1},
-            {language: 'en', score: 0.8},
-            {language: 'fr', score: 0.6}
+            {baseLanguage: 'en', language: 'en-US', score: 1},
+            {baseLanguage: 'en', language: 'en', score: 0.8},
+            {baseLanguage: 'fr', language: 'fr', score: 0.6}
           ];
 
           expect(service.fetchHeaderLanguages()).to.deep.equal(
@@ -51,7 +51,7 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should handle supported languages with country code', function() {
-          const service = this.subject();
+          const service = this.owner.lookup('service:best-language');
 
           const supportedLanguages = ['en-CA', 'en-US', 'fr'];
 
@@ -83,7 +83,7 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should handle supported languages with country code', function() {
-          const service = this.subject();
+          const service = this.owner.lookup('service:best-language');
 
           const supportedLanguages = ['en-CA', 'en-US', 'fr'];
 
@@ -120,7 +120,9 @@ describe('Unit | Service | best-language', () => {
         it('should fetch an empty string from the `Accept-Language` header', function() {
           const service = this.owner.lookup('service:best-language');
 
-          const expectedLanguages = [{language: '', score: 1}];
+          const expectedLanguages = [
+            {baseLanguage: '', language: '', score: 1}
+          ];
 
           expect(service.fetchHeaderLanguages()).to.deep.equal(
             expectedLanguages
@@ -174,9 +176,9 @@ describe('Unit | Service | best-language', () => {
           const service = this.owner.lookup('service:best-language');
 
           const expectedLanguages = [
-            {language: 'fr', score: 1},
-            {language: 'en-US', score: 0.9},
-            {language: 'en', score: 0.8}
+            {baseLanguage: 'fr', language: 'fr', score: 1},
+            {baseLanguage: 'en', language: 'en-US', score: 0.9},
+            {baseLanguage: 'en', language: 'en', score: 0.8}
           ];
 
           expect(service.fetchBrowserLanguages()).to.deep.equal(
@@ -207,9 +209,9 @@ describe('Unit | Service | best-language', () => {
           const service = this.owner.lookup('service:best-language');
 
           const expectedLanguages = [
-            {language: 'en-US', score: 1},
-            {language: 'en', score: 0.9},
-            {language: 'fr', score: 0.8}
+            {baseLanguage: 'en', language: 'en-US', score: 1},
+            {baseLanguage: 'en', language: 'en', score: 0.9},
+            {baseLanguage: 'fr', language: 'fr', score: 0.8}
           ];
 
           expect(service.fetchBrowserLanguages()).to.deep.equal(
@@ -273,7 +275,7 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should handle supported languages with country code', function() {
-          const service = this.subject();
+          const service = this.owner.lookup('service:best-language');
 
           const supportedLanguages = ['en-CA', 'en-US', 'fr'];
 
@@ -305,7 +307,7 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should handle supported languages with country code', function() {
-          const service = this.subject();
+          const service = this.owner.lookup('service:best-language');
 
           const supportedLanguages = ['en-CA', 'en-US', 'fr'];
 
@@ -345,28 +347,6 @@ describe('Unit | Service | best-language', () => {
         ];
 
         expect(service.sortLanguagesByScore(inputLanguages)).to.deep.equal(
-          expectedLanguages
-        );
-      });
-    });
-
-    describe('mapWithBaseLanguage', () => {
-      it('should add the base language in the language object', function() {
-        const service = this.owner.lookup('service:best-language');
-
-        const inputLanguages = [
-          {language: 'fr', score: 0.6},
-          {language: 'en-US', score: 1},
-          {language: 'en', score: 0.8}
-        ];
-
-        const expectedLanguages = [
-          {language: 'fr', baseLanguage: 'fr', score: 0.6},
-          {language: 'en-US', baseLanguage: 'en', score: 1},
-          {language: 'en', baseLanguage: 'en', score: 0.8}
-        ];
-
-        expect(service.mapWithBaseLanguage(inputLanguages)).to.deep.equal(
           expectedLanguages
         );
       });


### PR DESCRIPTION
The "supported languages" list can now include the country code.

Example:
```
const bestLanguageOrFirst = this.get('bestLanguage').bestLanguageOrFirst(['fr-CA', 'en-US']);
// => {language: 'fr-CA', baseLanguage: 'fr', score: 0}
```

Issue: #7