### PR TITLE
Do not use explicit tslint config

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prettier": "prettier --write '{addon,app,tests,config}/**/*.{ts,js}' ember-cli-build.js testem.js",
     "prettier-check": "prettier -l '{addon,app,tests,config}/**/*.{ts,js}' ember-cli-build.js testem.js",
     "lint": "node_modules/.bin/eslint '{addon,app,config,tests}/**/*.js' './index.js' ember-cli-build.js testem.js",
-    "lint-typescript": "tslint -c tslint.json '{addon,app,config,tests,config}/**/*.ts'",
+    "lint-typescript": "tslint '{addon,app,config,config,tests}/**/*.ts'",
     "prepublishOnly": "ember ts:precompile",
     "postpublish": "ember ts:clean"
   },

--- a/tests/tslint.json
+++ b/tests/tslint.json
@@ -1,6 +1,5 @@
 {
   "rules": {
-    "max-nested-callbacks": 0,
     "no-magic-numbers": false
   }
 }

--- a/tests/unit/services/best-language-test.ts
+++ b/tests/unit/services/best-language-test.ts
@@ -40,7 +40,9 @@ describe('Unit | Service | best-language', () => {
 
       describe('bestLanguage', () => {
         it('should return the best language when one matches', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['en', 'es'];
 
@@ -52,7 +54,9 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should handle supported languages with country code', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['en-CA', 'en-US', 'fr'];
 
@@ -64,7 +68,9 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should return `null` when none match', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['de', 'es'];
 
@@ -74,7 +80,9 @@ describe('Unit | Service | best-language', () => {
 
       describe('bestLanguageOrFirst', () => {
         it('should return the best language when one matches', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['en', 'es'];
 
@@ -84,7 +92,9 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should handle supported languages with country code', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['en-CA', 'en-US', 'fr'];
 
@@ -94,7 +104,9 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should return the first supported language when none match', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['de-DE', 'es'];
 
@@ -133,7 +145,9 @@ describe('Unit | Service | best-language', () => {
 
       describe('bestLanguage', () => {
         it('should return `null`', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['de', 'es'];
 
@@ -143,7 +157,9 @@ describe('Unit | Service | best-language', () => {
 
       describe('bestLanguageOrFirst', () => {
         it('should return the first supported language', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['de', 'es'];
 
@@ -264,7 +280,9 @@ describe('Unit | Service | best-language', () => {
 
       describe('bestLanguage', () => {
         it('should return the best language when one matches', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['en', 'es'];
 
@@ -276,7 +294,9 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should handle supported languages with country code', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['en-CA', 'en-US', 'fr'];
 
@@ -288,7 +308,9 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should return `null` when none match', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['de', 'es'];
 
@@ -298,7 +320,9 @@ describe('Unit | Service | best-language', () => {
 
       describe('bestLanguageOrFirst', () => {
         it('should return the best language when one matches', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['en', 'es'];
 
@@ -308,7 +332,9 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should handle supported languages with country code', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['en-CA', 'en-US', 'fr'];
 
@@ -318,7 +344,9 @@ describe('Unit | Service | best-language', () => {
         });
 
         it('should return the first supported language when none match', function() {
-          const service: BestLanguage = this.owner.lookup('service:best-language');
+          const service: BestLanguage = this.owner.lookup(
+            'service:best-language'
+          );
 
           const supportedLanguages = ['de-DE', 'es'];
 


### PR DESCRIPTION
There was two errors (and one warning) with the build

* **Error** → The `./tests/tslint.json` was ignored by `tslint` because we were passing explicitly `./tslint.json` as the main configuration file
* **Error** → The `tests/unit/services/best-language-test.ts` file was not properly formatted with Prettier
* **Warning** → The `max-nested-callbacks` rule doesn’t exist in `tslint` (it does in `eslint`)