### PR TITLE
Loosen yarn engines restriction to >= 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*",
-    "yarn": "1.16.0"
+    "yarn": ">= 1.16.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
I'm currently on yarn 1.17.3 and everything is working great. I was unsure if there are any other considerations for freezing this at 1.16.0.