### PR TITLE
Fix environment check

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -3,7 +3,7 @@
 'use strict';
 
 module.exports = function(env) {
-  if (!env === 'test') return {};
+  if (env !== 'test') return {};
 
   return {
     APP: {


### PR DESCRIPTION
Fixes a bad comparison that was causing host apps to have `autoboot: false` in their environment.

Resolves #31 