### PR TITLE
Stop using Sets to support IE11 without a polyfill

### DIFF
--- a/addon/services/best-language.ts
+++ b/addon/services/best-language.ts
@@ -57,19 +57,21 @@ export default class BestLanguage extends Service {
   }
 
   private fetchBrowserLanguages(): Language[] {
-    const languages = [
+    const browserLanguages = [
       ...(navigator.languages || []),
       navigator.language,
       (navigator as any).userLanguage
     ];
 
-    return Array.from(new Set(languages))
-      .filter(language => !!language)
-      .map((language, index, array) => ({
-        language,
-        baseLanguage: this.getBaseLanguage(language),
-        score: this.computeScore(index, array.length)
-      }));
+    const languages = browserLanguages.filter((language, index, array) => {
+      return !!language && array.indexOf(language) === index;
+    });
+
+    return languages.map((language, index, array) => ({
+      language,
+      baseLanguage: this.getBaseLanguage(language),
+      score: this.computeScore(index, array.length)
+    }));
   }
 
   private parseHeader(header: string): Language[] {


### PR DESCRIPTION
We had a single usage of `Set` to make an array contain only unique values, we remove it to make our addon work in IE11 without having to load a `Set` polyfill for one usage! 🎉 

Fixes #38 